### PR TITLE
Include default.css in NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "author": "haripo",
   "license": "MIT",
   "files": [
-    "lib"
+    "lib",
+    "default.css"
   ],
   "devDependencies": {
     "babel": "^6.5.2",


### PR DESCRIPTION
Hi, 

While trying this lib I noticed that the `default.css` file is not included in the distributed NPM package. I'm guessing it should be included since you reference it from the usage instructions. In this PR I added the css file to the white-list, I believe that should be enough to include it in the package.

Great library btw! 

Cheers,
J
