### PR TITLE
Change so panel colors never become undefined

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -85,7 +85,11 @@ export default class GitHubCalendar extends React.Component<Props, State> {
         var contribution = contributions[i][j];
         if (contribution === null) continue;
         const pos = this.getPanelPosition(i, j);
-        const color = this.props.panelColors[contribution.value];
+        const numOfColors = this.props.panelColors.length
+        const color =
+          contribution.value >= numOfColors
+            ? this.props.panelColors[numOfColors - 1]
+            : this.props.panelColors[contribution.value];
         const dom = (
           <rect
             key={ 'panel_key_' + i + '_' + j }


### PR DESCRIPTION
Currently if the number of contributions for a given day is above the number of colors given as valid panel colors, `undefined` is returned and you end up with the panel being black instead of just the final panel color. This PR fixes that by making it so if the contributions are above the number of valid panel colors, it just goes with the final listed panel color.