### PR TITLE
Add temp type guard

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,14 +1,14 @@
-import React, { ReactElement } from 'react';
 import dayjs from 'dayjs';
+import React, { ReactElement } from 'react';
 import Measure, { BoundingRect } from 'react-measure';
 
 interface Props {
-  weekNames: string[]
-  monthNames: string[]
-  panelColors: string[]
+  weekNames?: string[]
+  monthNames?: string[]
+  panelColors?: string[]
   values: { [date: string]: number }
   until: string
-  dateFormat: string
+  dateFormat?: string
   weekLabelAttributes: any | undefined
   monthLabelAttributes: any | undefined
   panelAttributes: any | undefined

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -76,6 +76,11 @@ export default class GitHubCalendar extends React.Component<Props, State> {
     const values = this.props.values;
     const until = this.props.until;
 
+    // TODO: More sophisticated typing
+    if (this.props.panelColors == undefined || this.props.weekNames == undefined || this.props.monthNames == undefined) {
+      return;
+    }
+
     var contributions = this.makeCalendarData(values, until, columns);
     var innerDom: ReactElement[] = [];
 


### PR DESCRIPTION
Add type guards in the render method to avoid type error.
`panelColors`, `weekNames`, `monthNames` are always non-undefined value because defaultProps is configured.