### PR TITLE
fix: make weekLabelAttributes, monthLabelAttributes, panelAttributes optional

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,9 +9,9 @@ interface Props {
   values: { [date: string]: number }
   until: string
   dateFormat?: string
-  weekLabelAttributes: any | undefined
-  monthLabelAttributes: any | undefined
-  panelAttributes: any | undefined
+  weekLabelAttributes?: any 
+  monthLabelAttributes?: any 
+  panelAttributes?: any
 }
 
 interface State {


### PR DESCRIPTION
```
Type error: Type '{ values: {}; until: string; panelColors: string[]; }' is missing the following properties from type 'Readonly<Props>': weekLabelAttributes, monthLabelAttributes, panelAttributes

  51 |       <h1 className="pt-3 pb-2">{track && track.name}</h1>
  52 |
> 53 |       <Calendar
     |        ^
  54 |         values={values}
  55 |         until={date)}
  56 |         panelColors={['#eeeeee', '#9be9a8', '#40c463', '#30a14e', '#216e39']}
```

This is using TypeScript `v5.1.6`