### PR TITLE
fix: invalid calender props on changing panel colors (demo page)

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -89,8 +89,10 @@
             </code>
             <code>
   &lt;Calendar
-    values={values} until={until}
-    weekNames={weekNames} monthNames={monthNames}/&gt;
+    values={values}
+    until={until}
+    panelColors={panelColors}
+  /&gt;
             </code>
           </pre>
         </div>
@@ -114,8 +116,11 @@
             </code>
             <code>
   &lt;Calendar
-    values={values} until={until}
-    weekNames={weekNames} monthNames={monthNames}/&gt;
+    values={values}
+    until={until}
+    weekNames={weekNames}
+    monthNames={monthNames}
+  /&gt;
             </code>
           </pre>
         </div>


### PR DESCRIPTION
On the web demo, the props passing to the calender component for customizing the panel colors are wrong.

Currently being:
`
<Calendar
    values={values} until={until}
    weekNames={weekNames} monthNames={monthNames}/>
`

While it should be (will be fixed with this pull request of mine):
`
<Calendar
    values={values}
    until={until}
    panelColors={panelColors}
/>
`